### PR TITLE
Remove API key from async event queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Set the following properties in **System Properties** or use scripting to apply 
 
 | Property                                      | Type     | Description                              | Notes                                                                 |
 |----------------------------------------------|----------|------------------------------------------|-----------------------------------------------------------------------|
-| `x_neuronow.gpt.openai.api.key`              | password | Your OpenAI API Key                      | **This will be visible in the event queue...for now...unless you change this yourself.** |
+| `x_neuronow.gpt.openai.api.key`              | password | Your OpenAI API Key                      | Previously logged in the event queue; now the key remains private. |
 | `x_neuronow.gpt.openai.assistantid`          | string   | Your Assistant ID                        |                                                                       |
 | `x_neuronow.gpt.chat.input.placeholder`      | string   | Placeholder for the portal chat input    | Already set by default.                                                                      |
 | `x_neuronow.gpt.openai.agent.name`           | string   | Display name shown for the AI            | Already set by default.                                                                      |

--- a/update/sys_script_include_5ff1ea0d838ed2104af4f065eeaad36e.xml
+++ b/update/sys_script_include_5ff1ea0d838ed2104af4f065eeaad36e.xml
@@ -230,8 +230,7 @@ gpt.prototype = {
                 msg: msg,
                 conversationId: conversationId,
                 threadId: this.threadId
-            }),
-            this.apiKey
+            })
         );
 
         return {


### PR DESCRIPTION
## Summary
- sanitize async event usage by not logging the API key
- clarify README that API key is now private

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685894d1104883268a8f26d837ad6b91